### PR TITLE
asPercent may be used as an aggregator

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -871,6 +871,7 @@ asPercent.params = [
   Param('total', ParamTypes.any),
   Param('nodes', ParamTypes.nodeOrTag, multiple=True),
 ]
+asPercent.aggregator = True
 
 
 def divideSeriesLists(requestContext, dividendSeriesList, divisorSeriesList):


### PR DESCRIPTION
We have customers using using `asPercent` as a callback for `groupByNode()`, and this seems to work fine in my tests:

```
replay@mst-nb:~$ curl 'http://localhost:8000/render' -d 'target=groupByNode(a.b.c.*, 2, "asPercent")' -d format=json | jq
[
  {
    "target": "c",
    "tags": {
      "name": "asPercent(a.b.c.1,sumSeries(a.b.c.*))"
    },
    "datapoints": [
      [
        33.33333333333333,
        1588003200
      ]
    ]
  }
]
```