### PR TITLE
making nodes in groupByNodes optional

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -4976,7 +4976,7 @@ groupByNodes.group = 'Combine'
 groupByNodes.params = [
   Param('seriesList', ParamTypes.seriesList, required=True),
   Param('callback', ParamTypes.aggOrSeriesFunc, required=True),
-  Param('nodes', ParamTypes.nodeOrTag, required=True, multiple=True),
+  Param('nodes', ParamTypes.nodeOrTag, multiple=True),
 ]
 
 

--- a/webapp/tests/test_functions.py
+++ b/webapp/tests/test_functions.py
@@ -3051,6 +3051,11 @@ class FunctionsTest(TestCase):
         ]
         verify_groupByNodes(expectedResult, "range",  1, 0)
 
+        expectedResult = [
+            TimeSeries('',0,1,1,[None]),
+        ]
+        verify_groupByNodes(expectedResult, "average")
+
     def test_exclude(self):
         seriesList = self._gen_series_list_with_data(
             key=['collectd.test-db1.load.value', 'collectd.test-db2.load.value', 'collectd.test-db3.load.value', 'collectd.test-db4.load.value'],


### PR DESCRIPTION
What do you think about that?

The documentation specifies the function signature as `groupByNodes(seriesList, callback, *nodes)` in https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.groupByNodes so according to regex logic `*` would allow `0` instances of `nodes`. I've seen some users submitting queries like:

```
groupByNodes(<some metrics>, 'average')
```

so basically they're just abusing `groupByNodes()` to do `averageSeries()`, which is weird but it works and the docs are not clearly saying that it shouldn't work.