### PR TITLE
weightedAverage: raise an InputParameterError exception if the number of series passed for the values is different to the number passed for the weights

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1013,6 +1013,9 @@ def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
   """
   sortedSeries={}
 
+  if len(seriesListAvg) != len(seriesListWeight):
+    raise InputParameterError('weightedAverage must receive the same number of series for seriesListAvg and seriesListWeight but received respectively %d and %d' % (len(seriesListAvg), len(seriesListWeight)))
+
   for seriesAvg, seriesWeight in izip_longest(seriesListAvg , seriesListWeight):
     key = aggKey(seriesAvg, nodes)
 

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1014,17 +1014,17 @@ def weightedAverage(requestContext, seriesListAvg, seriesListWeight, *nodes):
   sortedSeries={}
 
   for seriesAvg, seriesWeight in izip_longest(seriesListAvg , seriesListWeight):
-    if seriesAvg is not None:
-      key = aggKey(seriesAvg, nodes)
-      if key not in sortedSeries:
-        sortedSeries[key]={}
-      sortedSeries[key]['avg']=seriesAvg
+    key = aggKey(seriesAvg, nodes)
 
-    if seriesWeight is not None:
-      key = aggKey(seriesWeight, nodes)
-      if key not in sortedSeries:
-        sortedSeries[key]={}
-      sortedSeries[key]['weight']=seriesWeight
+    if key not in sortedSeries:
+      sortedSeries[key]={}
+    sortedSeries[key]['avg']=seriesAvg
+
+    key = aggKey(seriesWeight, nodes)
+
+    if key not in sortedSeries:
+      sortedSeries[key]={}
+    sortedSeries[key]['weight']=seriesWeight
 
   productList = []
 


### PR DESCRIPTION
- weightedAverage: raise an InputParameterError exception if the number of series passed for the values is different to the number passed for the weights
- reverted incorrect fix for 'weightedAverage' that would silently ignore unequal series length passed as input (introduced by https://github.com/grafana/graphite-web/pull/8)
